### PR TITLE
update cron job times

### DIFF
--- a/.github/workflows/daily-deploy.yml
+++ b/.github/workflows/daily-deploy.yml
@@ -2,7 +2,7 @@ name: daily-build
 
 on:
   schedule:
-    - cron: '25 3 * * *'
+    - cron: '25 7 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/weekly-bulletin.yml
+++ b/.github/workflows/weekly-bulletin.yml
@@ -2,7 +2,7 @@ name: weekly-bulletin
 
 on:
   schedule:
-    - cron: '20 17 * * 5'
+    - cron: '20 21 * * 5'
   
 permissions:
   contents: write


### PR DESCRIPTION
I forgot that GH Actions runs in UTC - times have been updated as below

| Job | UTC | EDT |
| -- | -- | -- |
| Weekly Bulletin | 2120 | 1720 |
| Daily Build | 0725 | 0325 |